### PR TITLE
PHP 8.1 Deprecation warning fixed

### DIFF
--- a/src/Timezones/Timezones.php
+++ b/src/Timezones/Timezones.php
@@ -55,7 +55,7 @@ class Timezones
      */
     public static function formatTimezone($timezone, $region)
     {
-        $time = new DateTime(null, new DateTimeZone($timezone));
+        $time = new DateTime('now', new DateTimeZone($timezone));
         $str_offset = $time->format('P');
 
         //clean up the html display


### PR DESCRIPTION
Passing null to DateTime is deprecated in PHP 8.1